### PR TITLE
Enable controlling inverter output power 

### DIFF
--- a/src/huawei_solar/bridge.py
+++ b/src/huawei_solar/bridge.py
@@ -407,6 +407,7 @@ INVERTER_REGISTERS = [
     rn.SHUTDOWN_TIME,
     rn.ACCUMULATED_YIELD_ENERGY,
     rn.DAILY_YIELD_ENERGY,
+    rn.ACTIVE_POWER_DERATING_FIXED_VALUE,
 ]
 
 # State and alarm registers can be combined with PV String readout

--- a/src/huawei_solar/register_names.py
+++ b/src/huawei_solar/register_names.py
@@ -257,6 +257,7 @@ SYSTEM_TIME_RAW = "system_time_raw"
 UNKNOWN_TIME_5 = "unknown_time_5"
 STARTUP = "startup"
 SHUTDOWN = "shutdown"
+ACTIVE_POWER_DERATING_FIXED_VALUE = "active_power_derating_fixed_value"
 GRID_CODE = "grid_code"
 TIME_ZONE = "time_zone"
 

--- a/src/huawei_solar/registers.py
+++ b/src/huawei_solar/registers.py
@@ -654,6 +654,7 @@ REGISTERS: dict[str, RegisterDefinition] = {
     rn.SYSTEM_TIME_RAW: U32Register("seconds", 1, 40000, 2),
     rn.STARTUP: U16Register(None, 1, 40200, 1, writeable=True, readable=False),
     rn.SHUTDOWN: U16Register(None, 1, 40201, 1, writeable=True, readable=False),
+    rn.ACTIVE_POWER_DERATING_FIXED_VALUE: I32Register("W", 1, 40126, 2, writeable=True),
     rn.GRID_CODE: U16Register(rv.GRID_CODES, 1, 42000, 1),
     rn.TIME_ZONE: I16Register("min", 1, 43006, 1, writeable=True),
     rn.WLAN_WAKEUP: I16Register(rv.WlanWakeup, 1, 45052, 1, writeable=True),


### PR DESCRIPTION
Add writable register 40126 (ACTIVE_POWER_DERATING_FIXED_VALUE) to enable controlling output inverter power.
