### PR TITLE
Update register_values.py - Typo on Line 448

### DIFF
--- a/src/huawei_solar/register_values.py
+++ b/src/huawei_solar/register_values.py
@@ -445,7 +445,7 @@ STATE_CODES_1 = {
     0b0000_0000_0000_0010: "Grid-Connected",
     0b0000_0000_0000_0100: "Grid-Connected normally",
     0b0000_0000_0000_1000: "Grid connection with derating due to power rationing",
-    0b0000_0000_0001_0000: "Grid connection with derating due to internalcauses of the solar inverter",
+    0b0000_0000_0001_0000: "Grid connection with derating due to internal causes of the solar inverter",
     0b0000_0000_0010_0000: "Normal stop",
     0b0000_0000_0100_0000: "Stop due to faults",
     0b0000_0000_1000_0000: "Stop due to power rationing",


### PR DESCRIPTION
Hi,
I hope this is the way I'm supposed to flag and submit edits, but this is in relation to line 448 that appears to have a typo in it.

Currently is contains this text:

"Grid connection with derating due to internalcauses of the solar inverter"

Suggest edit to fix the missing space, so it reads:

"Grid connection with derating due to internal causes of the solar inverter"

Thanks.