### PR TITLE
Fix pylint warning R0901

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ asyncio_mode=strict
 commands=flake8 src tests --max-line-length=120
 
 [testenv:pylint]
-commands=pylint src --max-line-length=120
+commands=pylint src --max-line-length=120 --max-parents=8
 
 [testenv:black]
 commands=black --check src tests setup.py


### PR DESCRIPTION
fix warning: "Too many ancestors (8/7)"