### PR TITLE
Fix gain for "Insulation Impedance Value"

### DIFF
--- a/src/huawei_solar/registers.py
+++ b/src/huawei_solar/registers.py
@@ -667,7 +667,7 @@ REGISTERS: dict[str, RegisterDefinition] = {
     rn.GRID_FREQUENCY: U16Register("Hz", 100, 32085),
     rn.EFFICIENCY: U16Register("%", 100, 32086),
     rn.INTERNAL_TEMPERATURE: I16Register("°C", 10, 32087),
-    rn.INSULATION_RESISTANCE: U16Register("MOhm", 100, 32088),
+    rn.INSULATION_RESISTANCE: U16Register("MOhm", 1000, 32088),
     rn.DEVICE_STATUS: U16Register(rv.DEVICE_STATUS_DEFINITIONS, 1, 32089),
     rn.FAULT_CODE: U16Register(None, 1, 32090),
     rn.STARTUP_TIME: TimestampRegister(32091),


### PR DESCRIPTION
change gain from 100 to 1000 - as described in
V3 (2023-01-17)

based on:  [Solar Inverter Modbus Interface Definitions V3.0.pdf](https://github.com/wlcrs/huawei-solar-lib/files/15029643/Solar.Inverter.Modbus.Interface.Definitions.V3.0.pdf)
