### PR TITLE
fix: treat all-ones as invalid in U64Register decode

### DIFF
--- a/src/huawei_solar/register_definitions/number.py
+++ b/src/huawei_solar/register_definitions/number.py
@@ -141,6 +141,19 @@ class U64Register(NumberRegister[int]):
     length = 4
     invalid_value = 2**63 - 1
 
+    def decode(self, values: tuple[Any, ...]) -> Result[int | None]:
+        """Decode unsigned 64-bit register.
+
+        Also treats all-ones (2^64 - 1) as invalid. This value occurs
+        when Modbus communication errors cause all registers to return
+        0xFFFF, which combines to 0xFFFFFFFFFFFFFFFF. Without this
+        check, the all-ones value passes through as a valid number and
+        corrupts total_increasing energy statistics in Home Assistant.
+        """
+        if values[0] == 2**64 - 1:
+            return Result(value=None, unit=None)
+        return super().decode(values)
+
 
 class I16Register(NumberRegister[int]):
     """Signed 16-bit register."""

--- a/tests/huawei_solar/register_definitions/test_number.py
+++ b/tests/huawei_solar/register_definitions/test_number.py
@@ -1,0 +1,93 @@
+"""Tests for number register decoding and encoding."""
+
+from huawei_solar.register_definitions.number import (
+    I16Register,
+    I32Register,
+    I64Register,
+    U16Register,
+    U32Register,
+    U64Register,
+)
+
+
+class TestInvalidValueDetection:
+    """Test that invalid/sentinel values are correctly detected during decode."""
+
+    def test_u16_all_ones_is_invalid(self) -> None:
+        """U16: 0xFFFF should decode to None (standard Huawei sentinel)."""
+        reg = U16Register("kWh", 1, 30000)
+        result = reg.decode((0xFFFF,))
+        assert result.value is None
+
+    def test_u32_all_ones_is_invalid(self) -> None:
+        """U32: 0xFFFFFFFF should decode to None (standard Huawei sentinel)."""
+        reg = U32Register("kWh", 1, 30000)
+        result = reg.decode((0xFFFFFFFF,))
+        assert result.value is None
+
+    def test_u64_huawei_sentinel_is_invalid(self) -> None:
+        """U64: 0x7FFFFFFFFFFFFFFF should decode to None (Huawei sentinel)."""
+        reg = U64Register("kWh", 100, 30000)
+        result = reg.decode((2**63 - 1,))
+        assert result.value is None
+
+    def test_u64_all_ones_is_invalid(self) -> None:
+        """U64: 0xFFFFFFFFFFFFFFFF should decode to None.
+
+        This value occurs during Modbus communication errors when all
+        registers return 0xFFFF. Without this check, it decodes to
+        ~1.84e17 kWh and permanently corrupts total_increasing statistics.
+        """
+        reg = U64Register("kWh", 100, 30000)
+        result = reg.decode((2**64 - 1,))
+        assert result.value is None
+
+    def test_u64_valid_value_passes(self) -> None:
+        """U64: Normal values should decode correctly with gain applied."""
+        reg = U64Register("kWh", 100, 30000)
+        result = reg.decode((123456,))
+        assert result.value == 1234.56
+
+    def test_u64_zero_is_valid(self) -> None:
+        """U64: Zero should decode to 0."""
+        reg = U64Register("kWh", 100, 30000)
+        result = reg.decode((0,))
+        assert result.value == 0
+
+    def test_i16_sentinel_is_invalid(self) -> None:
+        """I16: 0x7FFF should decode to None."""
+        reg = I16Register("kWh", 1, 30000)
+        result = reg.decode((2**15 - 1,))
+        assert result.value is None
+
+    def test_i32_sentinel_is_invalid(self) -> None:
+        """I32: 0x7FFFFFFF should decode to None."""
+        reg = I32Register("kWh", 1, 30000)
+        result = reg.decode((2**31 - 1,))
+        assert result.value is None
+
+    def test_i64_sentinel_is_invalid(self) -> None:
+        """I64: 0x7FFFFFFFFFFFFFFF should decode to None."""
+        reg = I64Register("kWh", 100, 30000)
+        result = reg.decode((2**63 - 1,))
+        assert result.value is None
+
+    def test_u16_ignore_invalid(self) -> None:
+        """U16 with ignore_invalid: 0xFFFF should pass through as valid."""
+        reg = U16Register("kWh", 1, 30000, ignore_invalid=True)
+        result = reg.decode((0xFFFF,))
+        assert result.value == 0xFFFF
+
+
+class TestGainApplication:
+    """Test that gain is correctly applied during decode."""
+
+    def test_gain_divides_value(self) -> None:
+        reg = U32Register("kWh", 100, 30000)
+        result = reg.decode((50000,))
+        assert result.value == 500.0
+
+    def test_gain_one_no_division(self) -> None:
+        reg = U32Register("W", 1, 30000)
+        result = reg.decode((1234,))
+        assert result.value == 1234


### PR DESCRIPTION
Fix U64Register not detecting all-ones (0xFFFFFFFFFFFFFFFF) as invalid

When Modbus communication errors occur (timeouts, framing errors), all registers return `0xFFFF`. For 64-bit unsigned registers, four `0xFFFF` words combine to `0xFFFFFFFFFFFFFFFF` (2^64 - 1).

The `U64Register.invalid_value` is set to `2^63 - 1` (Huawei's "register not available" sentinel), which does **not** match the all-ones value. As a result, the corrupt value passes through as valid and — after dividing by the register's gain of 100 — becomes **~1.84×10¹⁷ kWh**.

For `total_increasing` energy sensors (e.g. `TOTAL_SUPPLY_FROM_GRID`, `TOTAL_PV_ENERGY_YIELD`), this permanently corrupts Home Assistant's long-term statistics, requiring manual SQL intervention to fix.

This issue does not affect other register types:

| Type | invalid_value | All-ones value | Caught? |
|------|--------------|----------------|---------|
| U16  | 2¹⁶ − 1 (0xFFFF) | 0xFFFF | Yes |
| U32  | 2³² − 1 (0xFFFFFFFF) | 0xFFFFFFFF | Yes |
| **U64** | **2⁶³ − 1 (0x7FFF...)** | **0xFFFF...** | **No** |
| I16  | 2¹⁵ − 1 | −1 (≈ 0 after gain) | N/A |
| I32  | 2³¹ − 1 | −1 (≈ 0 after gain) | N/A |
| I64  | 2⁶³ − 1 | −1 (≈ 0 after gain) | N/A |

# Proposed Changes

Override `decode()` in `U64Register` to additionally treat `2^64 - 1` as invalid, returning `None` (same as the existing Huawei sentinel handling). The existing `invalid_value = 2^63 - 1` is preserved for Huawei's own "register not available" response.

Also: Adds `test_number.py` with 12 tests covering invalid value detection for all register types and gain application.

## Related Issues

fixes https://github.com/wlcrs/huawei_solar/issues/1258
