### PR TITLE
Add support for EMMA 31002 and 31003 registers and use EMMA_LOCAL_TIME (31003) for getting system time

### DIFF
--- a/src/huawei_solar/device/sun2000.py
+++ b/src/huawei_solar/device/sun2000.py
@@ -215,9 +215,9 @@ class SUN2000Device(HuaweiSolarDeviceWithLogin):
         """Get the system time from the inverter."""
         if self.primary_device and isinstance(self.primary_device, EMMADevice):
             # Inverters don't return their own system time when connected via EMMA.
-            # Instead, we need to read the system time from the EMMA device.
+            # Instead, we need to read the local time from the EMMA device.
 
-            return (await self.primary_device.get(rn.EMMA_SYSTEM_TIME)).value  # type: ignore[no-any-return]
+            return (await self.primary_device.get(rn.EMMA_LOCAL_TIME)).value  # type: ignore[no-any-return]
 
         return (await self.get(rn.SYSTEM_TIME_RAW)).value  # type: ignore[no-any-return]
 

--- a/src/huawei_solar/register_names.py
+++ b/src/huawei_solar/register_names.py
@@ -545,6 +545,8 @@ EMMA_MAXIMUM_FEED_GRID_POWER_PERCENT = RegisterName("emma_maximum_feed_grid_powe
 EMMA_3PHASE_IMBALANCE_CONTROL = RegisterName("emma_3phase_imbalance_control")
 EMMA_POWER_SUPPLY_CONFIGURATION = RegisterName("emma_power_supply_configuration")
 EMMA_CONSIDER_MAINS_FAULTY_IF = RegisterName("emma_consider_mains_faulty_if")
+EMMA_DST_STATE = RegisterName("emma_dst_state")
+EMMA_LOCAL_TIME = RegisterName("emma_local_time")
 EMMA_SYSTEM_TIME = RegisterName("emma_system_time")
 LOCAL_TIME_YEAR = RegisterName("local_time_year")
 

--- a/src/huawei_solar/registers.py
+++ b/src/huawei_solar/registers.py
@@ -815,10 +815,18 @@ EMMA_REGISTERS: dict[rn.RegisterName, RegisterDefinition[Any]] = {
         writeable=True,
         target_device=TargetDevice.EMMA,
     ),
+    rn.EMMA_DST_STATE: U16Register(None, 1, 31002, target_device=TargetDevice.EMMA),
+    rn.EMMA_LOCAL_TIME: U32Register(
+        "seconds",
+        1,
+        31003,
+        target_device=TargetDevice.EMMA,
+    ),
     rn.EMMA_SYSTEM_TIME: U32Register(
         "seconds",
         1,
         40470,
+        writeable=True,
         target_device=TargetDevice.EMMA,
     ),
     rn.LOCAL_TIME_YEAR: U16Register(


### PR DESCRIPTION
# Proposed Changes
Adds support for EMMA registers 31002 and 31003 with names EMMA_DST_STATUS and EMMA_LOCAL_TIME. Also adds write capability to EMMA register EMMA_SYSTEM_TIME, as defined in Huawei's documentation. Finally uses EMMA_LOCAL_TIME when selecting time in sun2000.py because EMMA_SYSTEM_TIME gives a unix timestamp back in time as many seconds as is the current time_zone+dst settings applied. This fixes optimizer timestamps being wrong.

fixes https://github.com/wlcrs/huawei_solar/issues/1265
