### PR TITLE
Honour wrapped ReadException and detect SmartLogger via ESN register

### DIFF
--- a/src/huawei_solar/device/__init__.py
+++ b/src/huawei_solar/device/__init__.py
@@ -83,6 +83,16 @@ async def detect_device_type(client: AsyncHuaweiSolarClient) -> tuple[type[Huawe
         return get_device_class_for_model(smartlogger_device_name), smartlogger_device_name
     _LOGGER.info("SMARTLOGGER_DEVICE_NAME is an illegal data address for unit ID %d.", client.unit_id)
 
+    # Some SmartLogger firmwares (e.g. SmartLogger3000A) expose neither MODEL_NAME nor
+    # SMARTLOGGER_DEVICE_NAME, but still respond to the equipment serial number register.
+    # A successful read there is a strong enough signal to identify the device as a
+    # SmartLogger; SmartLoggerDevice.supports_device() accepts any name that starts
+    # with "SmartLogger", so the generic model string keeps the contract.
+    if await _try_read_register(client, rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN) is not None:
+        _LOGGER.info("Detected SmartLogger via ESN register for unit ID %d.", client.unit_id)
+        return SmartLoggerDevice, "SmartLogger"
+    _LOGGER.info("SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN unavailable for unit ID %d.", client.unit_id)
+
     if await _detect_sdongle():
         return SDongleDevice, "SDongle"
 

--- a/src/huawei_solar/device/__init__.py
+++ b/src/huawei_solar/device/__init__.py
@@ -1,11 +1,12 @@
 """Definitions of the devices supported by this library."""
 
 from logging import getLogger
+from typing import Any
 
 from tmodbus.exceptions import IllegalDataAddressError
 
 from huawei_solar import register_names as rn
-from huawei_solar.exceptions import DeviceDetectionError
+from huawei_solar.exceptions import DeviceDetectionError, ReadException
 from huawei_solar.modbus_client import AsyncHuaweiSolarClient
 
 from .base import HuaweiSolarDevice, HuaweiSolarDeviceWithLogin
@@ -18,6 +19,26 @@ from .sun2000 import SUN2000Device
 _LOGGER = getLogger(__name__)
 
 DEFAULT_SDONGLE_UNIT_ID = 100
+
+# Modbus exception codes returned by devices when a register simply isn't
+# accessible. Different firmwares pick one or the other for the same condition,
+# so probing logic has to treat both as "fall through to the next probe".
+_FALLTHROUGH_MODBUS_EXCEPTION_CODES = frozenset({0x02, 0x03})
+
+
+async def _try_read_register(client: AsyncHuaweiSolarClient, register: str) -> Any | None:  # noqa: ANN401
+    """Read a register, returning ``None`` if the device reports it as inaccessible.
+
+    Re-raises any other modbus or transport error so genuine failures still surface.
+    """
+    try:
+        return (await client.get(register)).value
+    except IllegalDataAddressError:
+        return None
+    except ReadException as err:
+        if err.modbus_exception_code not in _FALLTHROUGH_MODBUS_EXCEPTION_CODES:
+            raise
+        return None
 
 
 def get_device_class_for_model(model_name: str) -> type[HuaweiSolarDevice]:
@@ -36,37 +57,31 @@ async def detect_device_type(client: AsyncHuaweiSolarClient) -> tuple[type[Huawe
     """Detect the type of the connected device."""
 
     async def _detect_sdongle() -> bool:
-        try:
-            device_search_status = (await client.get(rn.SDONGLE_DEVICE_SEARCH_STATUS)).value
-        except IllegalDataAddressError:
+        device_search_status = await _try_read_register(client, rn.SDONGLE_DEVICE_SEARCH_STATUS)
+        if device_search_status is None:
             _LOGGER.warning("Failed to detect device type for unit ID %d.", DEFAULT_SDONGLE_UNIT_ID)
             return False
-        else:
-            _LOGGER.debug(
-                "Successfully retrieved SDongle 'device search status' register for unit ID %d: %s",
-                DEFAULT_SDONGLE_UNIT_ID,
-                device_search_status,
-            )
-            return True
+        _LOGGER.debug(
+            "Successfully retrieved SDongle 'device search status' register for unit ID %d: %s",
+            DEFAULT_SDONGLE_UNIT_ID,
+            device_search_status,
+        )
+        return True
 
     # Unit ID 100 is typically used by an SDongle. Fast track checking for that.
     if client.unit_id == DEFAULT_SDONGLE_UNIT_ID and await _detect_sdongle():
         return SDongleDevice, "SDongle"
 
-    try:
-        model_name: str = (await client.get(rn.MODEL_NAME)).value
-    except IllegalDataAddressError:
-        _LOGGER.info("MODEL_NAME is an illegal data address for unit ID %d.", client.unit_id)
-    else:
+    model_name = await _try_read_register(client, rn.MODEL_NAME)
+    if model_name is not None:
         return get_device_class_for_model(model_name), model_name
+    _LOGGER.info("MODEL_NAME is an illegal data address for unit ID %d.", client.unit_id)
 
-    try:
-        # The SmartLogger does not have a MODEL_NAME register, so we need to detect it differently
-        smartlogger_device_name: str = (await client.get(rn.SMARTLOGGER_DEVICE_NAME)).value
-    except IllegalDataAddressError:
-        _LOGGER.info("SMARTLOGGER_DEVICE_NAME is an illegal data address for unit ID %d.", client.unit_id)
-    else:
+    # The SmartLogger does not have a MODEL_NAME register, so we need to detect it differently
+    smartlogger_device_name = await _try_read_register(client, rn.SMARTLOGGER_DEVICE_NAME)
+    if smartlogger_device_name is not None:
         return get_device_class_for_model(smartlogger_device_name), smartlogger_device_name
+    _LOGGER.info("SMARTLOGGER_DEVICE_NAME is an illegal data address for unit ID %d.", client.unit_id)
 
     if await _detect_sdongle():
         return SDongleDevice, "SDongle"

--- a/src/huawei_solar/device/__init__.py
+++ b/src/huawei_solar/device/__init__.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from typing import Any
 
-from tmodbus.exceptions import IllegalDataAddressError
+from tmodbus.exceptions import IllegalDataAddressError, IllegalDataValueError
 
 from huawei_solar import register_names as rn
 from huawei_solar.exceptions import DeviceDetectionError, ReadException
@@ -20,11 +20,6 @@ _LOGGER = getLogger(__name__)
 
 DEFAULT_SDONGLE_UNIT_ID = 100
 
-# Modbus exception codes returned by devices when a register simply isn't
-# accessible. Different firmwares pick one or the other for the same condition,
-# so probing logic has to treat both as "fall through to the next probe".
-_FALLTHROUGH_MODBUS_EXCEPTION_CODES = frozenset({0x02, 0x03})
-
 
 async def _try_read_register(client: AsyncHuaweiSolarClient, register: str) -> Any | None:  # noqa: ANN401
     """Read a register, returning ``None`` if the device reports it as inaccessible.
@@ -33,12 +28,18 @@ async def _try_read_register(client: AsyncHuaweiSolarClient, register: str) -> A
     """
     try:
         return (await client.get(register)).value
-    except IllegalDataAddressError:
-        return None
     except ReadException as err:
-        if err.modbus_exception_code not in _FALLTHROUGH_MODBUS_EXCEPTION_CODES:
-            raise
-        return None
+        # Modbus exception codes returned by devices when a register simply isn't
+        # accessible. Different firmwares pick one or the other for the same condition,
+        # so probing logic has to treat both as "fall through to the next probe".
+        if err.modbus_exception_code in {
+            IllegalDataValueError.error_code,
+            IllegalDataAddressError.error_code
+        }:
+            return None
+
+         # re-raise any other exception that occurred
+        raise
 
 
 def get_device_class_for_model(model_name: str) -> type[HuaweiSolarDevice]:
@@ -77,20 +78,20 @@ async def detect_device_type(client: AsyncHuaweiSolarClient) -> tuple[type[Huawe
         return get_device_class_for_model(model_name), model_name
     _LOGGER.info("MODEL_NAME is an illegal data address for unit ID %d.", client.unit_id)
 
-    # The SmartLogger does not have a MODEL_NAME register, so we need to detect it differently
-    smartlogger_device_name = await _try_read_register(client, rn.SMARTLOGGER_DEVICE_NAME)
-    if smartlogger_device_name is not None:
-        return get_device_class_for_model(smartlogger_device_name), smartlogger_device_name
-    _LOGGER.info("SMARTLOGGER_DEVICE_NAME is an illegal data address for unit ID %d.", client.unit_id)
-
+    # The SmartLogger does not have a MODEL_NAME register, so we need to detect it differently.
+    #
     # Some SmartLogger firmwares (e.g. SmartLogger3000A) expose neither MODEL_NAME nor
     # SMARTLOGGER_DEVICE_NAME, but still respond to the equipment serial number register.
     # A successful read there is a strong enough signal to identify the device as a
     # SmartLogger; SmartLoggerDevice.supports_device() accepts any name that starts
     # with "SmartLogger", so the generic model string keeps the contract.
-    if await _try_read_register(client, rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN) is not None:
+    if (await _try_read_register(client, rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN)) is not None:
         _LOGGER.info("Detected SmartLogger via ESN register for unit ID %d.", client.unit_id)
-        return SmartLoggerDevice, "SmartLogger"
+
+        # fallback for when SMARTLOGGER_DEVICE_NAME is not available
+        smartlogger_device_name = (await _try_read_register(client, rn.SMARTLOGGER_DEVICE_NAME)) or "SmartLogger"
+
+        return SmartLoggerDevice, smartlogger_device_name
     _LOGGER.info("SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN unavailable for unit ID %d.", client.unit_id)
 
     if await _detect_sdongle():

--- a/tests/huawei_solar/device/test_device_detection.py
+++ b/tests/huawei_solar/device/test_device_detection.py
@@ -98,10 +98,9 @@ async def test_detect_device_type_smartlogger_when_model_name_illegal(
 ) -> None:
     def side_effect(register: str) -> Any:  # noqa: ANN401
         if register == rn.MODEL_NAME:
-            raise IllegalDataAddressError(
-                error_code=IllegalDataAddressError.error_code,
-                function_code=FunctionCode.READ_HOLDING_REGISTERS,
-            )
+            raise ReadException(_READ_FAILED_MSG, modbus_exception_code=IllegalDataAddressError.error_code)
+        if register == rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN:
+            return _value_result("123456789012")
         if register == rn.SMARTLOGGER_DEVICE_NAME:
             return _value_result("smartlogger-model")
         msg = f"Unexpected register read: {register!r}"
@@ -125,6 +124,8 @@ async def test_detect_device_type_smartlogger_when_model_name_read_exception(
     def side_effect(register: str) -> Any:  # noqa: ANN401
         if register == rn.MODEL_NAME:
             raise ReadException(_READ_FAILED_MSG, modbus_exception_code=modbus_exception_code)
+        if register == rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN:
+            return _value_result("123456789012")
         if register == rn.SMARTLOGGER_DEVICE_NAME:
             return _value_result("smartlogger-model")
         msg = f"Unexpected register read: {register!r}"
@@ -192,9 +193,9 @@ async def test_detect_device_type_smartlogger_via_esn_fallback() -> None:
 async def test_detect_device_type_sdongle_fallback_when_other_registers_illegal() -> None:
     def side_effect(register: str) -> Any:  # noqa: ANN401
         if register in (rn.MODEL_NAME, rn.SMARTLOGGER_DEVICE_NAME, rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN):
-            raise IllegalDataAddressError(
-                error_code=IllegalDataAddressError.error_code,
-                function_code=FunctionCode.READ_HOLDING_REGISTERS,
+            raise ReadException(
+                _READ_FAILED_MSG,
+                modbus_exception_code=IllegalDataAddressError.error_code,
             )
         if register == rn.SDONGLE_DEVICE_SEARCH_STATUS:
             return _value_result("done")
@@ -217,9 +218,9 @@ async def test_detect_device_type_raises_when_no_detection_path_matches() -> Non
             rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN,
             rn.SDONGLE_DEVICE_SEARCH_STATUS,
         ):
-            raise IllegalDataAddressError(
-                error_code=IllegalDataAddressError.error_code,
-                function_code=FunctionCode.READ_HOLDING_REGISTERS,
+            raise ReadException(
+                _READ_FAILED_MSG,
+                modbus_exception_code=IllegalDataAddressError.error_code,
             )
         msg = f"Unexpected register read: {register!r}"
         raise AssertionError(msg)

--- a/tests/huawei_solar/device/test_device_detection.py
+++ b/tests/huawei_solar/device/test_device_detection.py
@@ -170,9 +170,28 @@ async def test_detect_device_type_sdongle_fast_track_on_unit_100() -> None:
     assert detected_name == "SDongle"
 
 
-async def test_detect_device_type_sdongle_fallback_when_other_registers_illegal() -> None:
+async def test_detect_device_type_smartlogger_via_esn_fallback() -> None:
+    """Firmwares with neither MODEL_NAME nor SMARTLOGGER_DEVICE_NAME still expose the ESN."""
+
     def side_effect(register: str) -> Any:  # noqa: ANN401
         if register in (rn.MODEL_NAME, rn.SMARTLOGGER_DEVICE_NAME):
+            raise ReadException(_READ_FAILED_MSG, modbus_exception_code=0x03)
+        if register == rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN:
+            return _value_result("102120056473")
+        msg = f"Unexpected register read: {register!r}"
+        raise AssertionError(msg)
+
+    client = _client_with_get(unit_id=7, side_effect=side_effect)
+
+    detected_class, detected_name = await detect_device_type(client)
+
+    assert detected_class is SmartLoggerDevice
+    assert detected_name == "SmartLogger"
+
+
+async def test_detect_device_type_sdongle_fallback_when_other_registers_illegal() -> None:
+    def side_effect(register: str) -> Any:  # noqa: ANN401
+        if register in (rn.MODEL_NAME, rn.SMARTLOGGER_DEVICE_NAME, rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN):
             raise IllegalDataAddressError(
                 error_code=IllegalDataAddressError.error_code,
                 function_code=FunctionCode.READ_HOLDING_REGISTERS,
@@ -192,7 +211,12 @@ async def test_detect_device_type_sdongle_fallback_when_other_registers_illegal(
 
 async def test_detect_device_type_raises_when_no_detection_path_matches() -> None:
     def side_effect(register: str) -> Any:  # noqa: ANN401
-        if register in (rn.MODEL_NAME, rn.SMARTLOGGER_DEVICE_NAME, rn.SDONGLE_DEVICE_SEARCH_STATUS):
+        if register in (
+            rn.MODEL_NAME,
+            rn.SMARTLOGGER_DEVICE_NAME,
+            rn.SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN,
+            rn.SDONGLE_DEVICE_SEARCH_STATUS,
+        ):
             raise IllegalDataAddressError(
                 error_code=IllegalDataAddressError.error_code,
                 function_code=FunctionCode.READ_HOLDING_REGISTERS,

--- a/tests/huawei_solar/device/test_device_detection.py
+++ b/tests/huawei_solar/device/test_device_detection.py
@@ -10,12 +10,14 @@ from huawei_solar.device.scharger import SChargerDevice
 from huawei_solar.device.sdongle import SDongleDevice
 from huawei_solar.device.smartlogger import SmartLoggerDevice
 from huawei_solar.device.sun2000 import SUN2000Device
-from huawei_solar.exceptions import DeviceDetectionError
+from huawei_solar.exceptions import DeviceDetectionError, ReadException
 from tmodbus.const import FunctionCode
 from tmodbus.exceptions import IllegalDataAddressError
 
 from huawei_solar import register_names as rn
 from huawei_solar.device import DEFAULT_SDONGLE_UNIT_ID, detect_device_type, get_device_class_for_model
+
+_READ_FAILED_MSG = "Failed to read register"
 
 
 def _value_result(value: str) -> SimpleNamespace:
@@ -111,6 +113,46 @@ async def test_detect_device_type_smartlogger_when_model_name_illegal(
 
     assert detected_class is SmartLoggerDevice
     assert detected_name == "smartlogger-model"
+
+
+@pytest.mark.parametrize("modbus_exception_code", [0x02, 0x03])
+async def test_detect_device_type_smartlogger_when_model_name_read_exception(
+    patched_supports_device: None,
+    modbus_exception_code: int,
+) -> None:
+    """register_client.get() wraps modbus exceptions in ReadException — the fallback chain must follow."""
+
+    def side_effect(register: str) -> Any:  # noqa: ANN401
+        if register == rn.MODEL_NAME:
+            raise ReadException(_READ_FAILED_MSG, modbus_exception_code=modbus_exception_code)
+        if register == rn.SMARTLOGGER_DEVICE_NAME:
+            return _value_result("smartlogger-model")
+        msg = f"Unexpected register read: {register!r}"
+        raise AssertionError(msg)
+
+    client = _client_with_get(unit_id=1, side_effect=side_effect)
+
+    detected_class, detected_name = await detect_device_type(client)
+
+    assert detected_class is SmartLoggerDevice
+    assert detected_name == "smartlogger-model"
+
+
+async def test_detect_device_type_propagates_unrelated_read_exception(
+    patched_supports_device: None,
+) -> None:
+    """Modbus exception codes other than 0x02/0x03 must propagate, not be swallowed."""
+
+    def side_effect(register: str) -> Any:  # noqa: ANN401
+        if register == rn.MODEL_NAME:
+            raise ReadException(_READ_FAILED_MSG, modbus_exception_code=0x04)  # Server Device Failure
+        msg = f"Unexpected register read: {register!r}"
+        raise AssertionError(msg)
+
+    client = _client_with_get(unit_id=1, side_effect=side_effect)
+
+    with pytest.raises(ReadException):
+        await detect_device_type(client)
 
 
 async def test_detect_device_type_sdongle_fast_track_on_unit_100() -> None:


### PR DESCRIPTION
## Proposed Changes

Fixes SmartLogger detection in `detect_device_type` for firmwares that
return Modbus exception `0x03` (Illegal Data Value) for `MODEL_NAME` and
`SMARTLOGGER_DEVICE_NAME`, and aligns the existing fallback chain with
how exceptions actually propagate from `register_client.get()`.

Reproduced on a **SmartLogger3000A** acting as a Modbus TCP gateway in
front of 4 SUN2000 inverters, 1 LUNA 2000 battery and 1 power meter.

### What was broken

1. `register_client.get_multiple()` (see `register_client.py:106`) wraps
   every `ModbusResponseError` into a `ReadException` carrying the
   original `modbus_exception_code`. The fallback chain in
   `detect_device_type` only caught the raw `IllegalDataAddressError`,
   so against a real client every branch fell through unhandled and
   `create_device_instance` aborted detection. The pre-existing tests
   mocked `client.get()` to raise `IllegalDataAddressError` directly,
   so the gap was invisible from the suite.

2. Some SmartLogger firmwares — confirmed on a SmartLogger3000A —
   answer **Modbus exception `0x03` (Illegal Data Value)** instead of
   `0x02` (Illegal Data Address) for registers they do not expose, and
   expose neither `MODEL_NAME` (30000) nor `SMARTLOGGER_DEVICE_NAME`
   (65524). The detection chain had no further fallback for that
   combination, so the device could not be added even though it was
   reachable and behaved correctly as a Modbus TCP gateway for its
   sub-devices.

### Reproduction

Reads against the SmartLogger3000A on its configured comm address:

```
$ mbpoll -m tcp -a 7 -r 30000 -c 15 -t 4 -0 -1 <ip>
-- Polling slave 7...
Read output (holding) register failed: Illegal data value     # MODEL_NAME

$ mbpoll -m tcp -a 7 -r 65524 -c 10 -t 4 -0 -1 <ip>
-- Polling slave 7...
Read output (holding) register failed: Illegal data value     # SMARTLOGGER_DEVICE_NAME

$ mbpoll -m tcp -a 7 -r 40713 -c 10 -t 4 -0 -1 <ip>
-- Polling slave 7...
[40713]:        12592   # 0x3030 → "00"
[40714]:        12849   # 0x3231 → "21"
...
```

`ESN @ 40713` returns the SmartLogger serial number as ASCII, confirming
the register is accessible while the other two are not.

### Fix

Two commits:

1. **Honour `ReadException` in `detect_device_type` fallback paths.**
   Extracts the three try/except blocks into a `_try_read_register`
   helper that also treats `ReadException` with `modbus_exception_code`
   in `(0x02, 0x03)` as "register not accessible, fall through". Other
   codes still propagate so genuine read failures aren't swallowed.
   Three new tests cover the wrapped path (parametrised over `0x02`
   and `0x03`) and assert that an unrelated code is re-raised.

2. **Detect SmartLogger via `SMARTLOGGER_EQUIPMENT_SERIAL_NUMBER_ESN`.**
   After `MODEL_NAME` and `SMARTLOGGER_DEVICE_NAME` both fall through,
   probe ESN at register 40713. A successful read is sufficient to
   identify the device as a SmartLogger; the generic model string
   `"SmartLogger"` is returned, matched by
   `SmartLoggerDevice.supports_device()` via `startswith("SmartLogger")`.
   The same ESN is then read again by
   `SmartLoggerDevice._populate_additional_fields` when the instance is
   created, populating its `serial_number` field. A new test covers
   the path; two pre-existing tests that drove the chain to its end
   are extended to mock the ESN register as inaccessible.

### Documentation reference

Per Huawei *SmartLogger ModBus Interface Definitions*, **Issue 35
(2020-02-20), Table 2-1 SN 49**, ESN is defined as a read-only `STR`
register at address **40713**, quantity 10 — a SmartLogger-specific
identifier, distinct from the `MODEL_NAME` (30000, only listed in the
SUN2000 protocol document) and the public `Device name` register (65524,
Table 2-6 SN 4, which is meant to be queried per sub-device).

### Verification

```
$ uv run pytest
============================= 111 passed in 0.29s ==============================

$ uv run ruff check
All checks passed!
```

## Related Issues

- wlcrs/huawei_solar#1342 — *"[Bug]: SmartLogger 3000A meter not
  discovered + IllegalDataValueError with elevated permissions"*. This
  PR resolves the SmartLogger detection part of that report. Meter
  discovery through the SmartLogger gateway is a separate concern (the
  library has no `MeterDevice` class) and is out of scope here.
